### PR TITLE
Add monthly accrual function

### DIFF
--- a/scheduler/views.py
+++ b/scheduler/views.py
@@ -1,0 +1,31 @@
+from settings.models import Profile
+
+from datetime import date
+
+
+# Internal helper functions
+def accrue_days():
+    """
+    Adds monthly accrual days to all users who have not yet
+    accrued days in the current month
+    """
+    # Get the current month in ISO format
+    today = date.today()
+    current_month = today.strftime('%Y-%m-01T00:00:00.000Z')
+
+    # Get profiles that have not been updated yet this month
+    profiles = Profile.objects.filter(update_timestamp__lt=current_month)
+
+    for profile in profiles:
+        # Get the monthly accrual days and max allowable accrual days
+        monthly_accrual_days = profile.annual_accrual_days / 12
+        max_allowable_accrual_days = profile.max_allowable_accrual_days
+
+        # Add the monthly accrual days to the remaining accrual days
+        profile.remaining_accrual_days += monthly_accrual_days
+
+        # If the remaining accrual days exceeds the max, set it to the max
+        if profile.remaining_accrual_days > max_allowable_accrual_days:
+            profile.remaining_accrual_days = max_allowable_accrual_days
+
+        profile.save()

--- a/settings/views.py
+++ b/settings/views.py
@@ -13,6 +13,7 @@ from django.contrib.auth.decorators import (
 from django.contrib import messages
 
 from settings.models import Profile
+from scheduler.views import accrue_days
 
 
 # Internal helper
@@ -152,6 +153,9 @@ def all_users_settings(request):
     """
     Displays and allows for edits to all users in the system
     """
+    # Accrue monthly days for each user who hasn't yet accrued this month
+    accrue_days()
+
     if request.method == 'POST':
         try:
             data = request.POST


### PR DESCRIPTION
- adds monthly accrual allotment to each user's remaining accrual balance when a user loads the `settings/users/all` page if an accrual has not yet occurred this month